### PR TITLE
Add compatibility for kubeJS's modifications

### DIFF
--- a/Common/src/main/java/com/almostreliable/attributetooltipfix/mixin/AttributeModifierMixin.java
+++ b/Common/src/main/java/com/almostreliable/attributetooltipfix/mixin/AttributeModifierMixin.java
@@ -1,10 +1,13 @@
 package com.almostreliable.attributetooltipfix.mixin;
 
+import com.almostreliable.attributetooltipfix.AttributeTooltipFix;
 import com.almostreliable.attributetooltipfix.UUIDSwap;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.UUID;
 
@@ -14,5 +17,15 @@ public class AttributeModifierMixin {
     @ModifyVariable(method = "load", at = @At("STORE"), ordinal = 0)
     private static UUID load(UUID uuid) {
         return UUIDSwap.swapOrSelf(uuid);
+    }
+
+    @ModifyVariable(
+            method = "<init>(Ljava/util/UUID;Ljava/util/function/Supplier;DLnet/minecraft/world/entity/ai/attributes/AttributeModifier$Operation;)V",
+            at = @At("HEAD"),
+            argsOnly = true,
+            ordinal = 0
+    )
+    private static UUID modifyUUID(UUID original) {
+        return UUIDSwap.swapOrSelf(original);
     }
 }


### PR DESCRIPTION
# Changes: 
**Add compatibility for kubeJS's modifications**

## Proposed Changes

- fixed the Incompatible with KubeJS.

### Detail

Although KubeJS script already used correct UUID, 

but previous version can't show correctly.

KubeJS scripts are followings:
```
ItemEvents.modification(event=>{
  event.modify('minecraft:golden_sword', item =>{
    item.removeAttribute('minecraft:generic.attack_damage', 'CB3F55D3-645C-4F38-A497-9C13A33DB5CF')
    item.addAttribute(
      'minecraft:generic.attack_damage',
      'CB3F55D3-645C-4F38-A497-9C13A33DB5CF',
      'ddddddddd',
      9,
      'addition'
    )
  })
})
```
### Previous Effect:(Using KubeJS Script)

![Previous Effect1](https://s3.bmp.ovh/imgs/2025/07/15/d5875945c3b30d78.png)

![Previous Effect2](https://s3.bmp.ovh/imgs/2025/07/15/0877cec35817074b.png)

### Now Effect:(Using KubeJS Script)

![Now Effect1](https://s3.bmp.ovh/imgs/2025/07/15/b24a33432ff0aa41.png)

![Now Effect2](https://s3.bmp.ovh/imgs/2025/07/15/06baa55e4fc6d051.png)

## The reason for not working:

The previous code only uses

```
@ModifyVariable(method = "load", at = @At("STORE"), ordinal = 0)
    private static UUID load(UUID uuid) {
        return UUIDSwap.swapOrSelf(uuid);
    }
```

But one problem is that when modifying the attributes of an item through ItemAttributeModifierEvent, the Mixin logic of AttributeModifier. load() will not be triggered again.

The Mixin of AttributeModifier. load() only takes effect when loading attribute modifiers from NBT data (during the static data parsing phase).

So, your previous version can only managers the items borned from command blocks, because them have NBTs.

But now, I change the method, I intercept the construction process of AttributeModifier. It works well, and compatible with all.

## Additional Context

### Changed Codes

![Changed Codes](https://s3.bmp.ovh/imgs/2025/07/15/5228aad3aa4636c5.png)

### Sword With No NBT(By Script)

![Sword With No NBT](https://s3.bmp.ovh/imgs/2025/07/15/b48841a549191676.png)

### Sword With NBT(Your Command)

![Sword With NBT](https://s3.bmp.ovh/imgs/2025/07/15/5769d0a34c2e7347.png)

<!-- 💚 Thank you for contributing! -->
